### PR TITLE
fix: chome support for supportedValuesOf in v99

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -98,7 +98,7 @@
             "spec_url": "https://tc39.es/proposal-intl-enumeration/#sec-intl.supportedvaluesof",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Chrome added support for supportedValues of in v99

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Tested in console in my browser.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See: https://chromestatus.com/feature/5649454590853120


<!-- ✅ After submitting, review the results of the "Checks" tab! -->
